### PR TITLE
Add collapsible sidebar and task form to dashboard

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -33,6 +33,38 @@
             background-color: #e6fffa;
             border-left: 4px solid #38a169;
         }
+        .sidebar {
+            transition: width 0.3s ease;
+        }
+        .sidebar.collapsed {
+            width: 4rem;
+        }
+        .sidebar.collapsed .sidebar-text,
+        .sidebar.collapsed .sidebar-footer-text,
+        .sidebar.collapsed .sidebar-section-label {
+            display: none;
+        }
+        .sidebar.collapsed .sidebar-link {
+            justify-content: center;
+            padding-left: 0;
+            padding-right: 0;
+        }
+        .sidebar.collapsed .sidebar-icon {
+            margin-right: 0;
+        }
+        .sidebar.collapsed .sidebar-footer {
+            justify-content: center;
+            gap: 0.5rem;
+        }
+        .sidebar.collapsed .sidebar-footer img {
+            margin-right: 0;
+        }
+        .sidebar.collapsed .sidebar-header {
+            justify-content: center;
+        }
+        .sidebar.collapsed .sidebar-toggle {
+            align-self: center;
+        }
         .task-item:hover {
             background-color: #f0fff4;
         }
@@ -107,45 +139,47 @@
     <!-- Dashboard Layout -->
     <div class="flex pt-16">
         <!-- Sidebar -->
-        <div class="hidden md:flex md:flex-shrink-0">
-            <div class="flex flex-col w-64 border-r border-gray-200 bg-white">
+        <div id="sidebarContainer" class="hidden md:flex md:flex-shrink-0">
+            <div id="sidebar" class="sidebar flex flex-col w-64 border-r border-gray-200 bg-white">
                 <div class="h-0 flex-1 flex flex-col pt-5 pb-4 overflow-y-auto">
-                    <div class="flex-1 px-3 space-y-1">
-                        <a href="dashboard.html" class="sidebar-item active group flex items-center px-2 py-2 text-sm font-medium rounded-md">
-                            <i data-feather="home" class="mr-3 h-6 w-6 text-green-500"></i>
-                            Dashboard
+                    <div class="sidebar-header flex items-center justify-between px-3">
+                        <p class="sidebar-section-label text-xs font-semibold text-gray-500 uppercase tracking-wider">Navigation</p>
+                        <button type="button" id="sidebarToggle" class="sidebar-toggle text-gray-500 hover:text-green-600 focus:outline-none transform transition-transform duration-300" aria-expanded="true" aria-label="Toggle sidebar">
+                            <i data-feather="chevron-left"></i>
+                        </button>
+                    </div>
+                    <div class="flex-1 mt-5 px-3 space-y-1">
+                        <a href="dashboard.html" class="sidebar-link sidebar-item active group flex items-center px-2 py-2 text-sm font-medium rounded-md">
+                            <i data-feather="home" class="sidebar-icon mr-3 h-6 w-6 text-green-500"></i>
+                            <span class="sidebar-text">Dashboard</span>
                         </a>
-                        <a href="tasks.html" class="sidebar-item group flex items-center px-2 py-2 text-sm font-medium rounded-md">
-                            <i data-feather="check-circle" class="mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500"></i>
-                            Tasks
+                        <a href="tasks.html" class="sidebar-link sidebar-item group flex items-center px-2 py-2 text-sm font-medium rounded-md">
+                            <i data-feather="check-circle" class="sidebar-icon mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500"></i>
+                            <span class="sidebar-text">Tasks</span>
                         </a>
-                        <a href="calendar.html" class="sidebar-item group flex items-center px-2 py-2 text-sm font-medium rounded-md">
-                            <i data-feather="calendar" class="mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500"></i>
-                            Calendar
+                        <a href="calendar.html" class="sidebar-link sidebar-item group flex items-center px-2 py-2 text-sm font-medium rounded-md">
+                            <i data-feather="calendar" class="sidebar-icon mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500"></i>
+                            <span class="sidebar-text">Calendar</span>
                         </a>
-                        <a href="analytics.html" class="sidebar-item group flex items-center px-2 py-2 text-sm font-medium rounded-md">
-                            <i data-feather="bar-chart-2" class="mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500"></i>
-                            Analytics
+                        <a href="analytics.html" class="sidebar-link sidebar-item group flex items-center px-2 py-2 text-sm font-medium rounded-md">
+                            <i data-feather="bar-chart-2" class="sidebar-icon mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500"></i>
+                            <span class="sidebar-text">Analytics</span>
                         </a>
-                        <a href="wellness.html" class="sidebar-item group flex items-center px-2 py-2 text-sm font-medium rounded-md">
-                            <i data-feather="heart" class="mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500"></i>
-                            Wellness
+                        <a href="wellness.html" class="sidebar-link sidebar-item group flex items-center px-2 py-2 text-sm font-medium rounded-md">
+                            <i data-feather="heart" class="sidebar-icon mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500"></i>
+                            <span class="sidebar-text">Wellness</span>
                         </a>
-                        <a href="settings.html" class="sidebar-item group flex items-center px-2 py-2 text-sm font-medium rounded-md">
-                            <i data-feather="settings" class="mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500"></i>
-                            Settings
+                        <a href="settings.html" class="sidebar-link sidebar-item group flex items-center px-2 py-2 text-sm font-medium rounded-md">
+                            <i data-feather="settings" class="sidebar-icon mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500"></i>
+                            <span class="sidebar-text">Settings</span>
                         </a>
                     </div>
                 </div>
-                <div class="flex-shrink-0 flex border-t border-gray-200 p-4">
-                    <div class="flex items-center">
-                        <div>
-                            <img class="h-10 w-10 rounded-full" src="http://static.photos/people/200x200/4" alt="User profile">
-                        </div>
-                        <div class="ml-3">
-                            <p class="text-base font-medium text-gray-700">John Doe</p>
-                            <p class="text-sm font-medium text-gray-500">View profile</p>
-                        </div>
+                <div class="sidebar-footer flex-shrink-0 flex border-t border-gray-200 p-4 items-center">
+                    <img class="h-10 w-10 rounded-full" src="http://static.photos/people/200x200/4" alt="User profile">
+                    <div class="sidebar-footer-text ml-3">
+                        <p class="text-base font-medium text-gray-700">John Doe</p>
+                        <p class="text-sm font-medium text-gray-500">View profile</p>
                     </div>
                 </div>
             </div>
@@ -193,7 +227,7 @@
                                 </p>
                             </div>
                             <div class="bg-white px-4 py-5 sm:p-6">
-                                <ul class="divide-y divide-gray-200">
+                                <ul id="priorityTasksList" class="divide-y divide-gray-200">
                                     <li class="task-item py-4">
                                         <div class="flex items-center">
                                             <input id="task-1" name="task-1" type="checkbox" class="task-checkbox h-4 w-4 text-green-600 focus:ring-green-500 border-gray-300 rounded">
@@ -240,12 +274,21 @@
                                         </div>
                                     </li>
                                 </ul>
-                                <div class="mt-4">
-                                    <button class="text-green-600 hover:text-green-800 text-sm font-medium flex items-center">
-                                        <i data-feather="plus" class="mr-1 h-4 w-4"></i>
+                                <form id="addTaskForm" class="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3" autocomplete="off">
+                                    <div class="flex-1">
+                                        <label for="newTaskText" class="sr-only">Task description</label>
+                                        <input type="text" id="newTaskText" name="newTaskText" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-green-500 focus:ring-green-500 text-sm" placeholder="Add a new priority task" required>
+                                    </div>
+                                    <div class="sm:w-32">
+                                        <label for="newTaskTime" class="sr-only">Due time</label>
+                                        <input type="time" id="newTaskTime" name="newTaskTime" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-green-500 focus:ring-green-500 text-sm">
+                                    </div>
+                                    <button type="submit" class="btn-primary text-white px-4 py-2 rounded-md text-sm font-medium flex items-center justify-center">
+                                        <i data-feather="plus" class="mr-2 h-4 w-4"></i>
                                         Add task
                                     </button>
-                                </div>
+                                </form>
+                                <p class="mt-2 text-xs text-gray-500">Capture quick priorities and optionally set a due time for today.</p>
                             </div>
                         </div>
                     </div>
@@ -340,6 +383,117 @@
                                         </div>
                                         <div class="ml-4">
                                             <p class="text-sm font-medium text-gray-500">Break Adherence</p>
-                                            <p class="text-lg font-bold text-gray-900">68
+                                            <p class="text-lg font-bold text-gray-900">68%</p>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="bg-gray-50 p-4 rounded-lg">
+                                    <div class="flex items-center">
+                                        <div class="flex-shrink-0 bg-green-100 rounded-md p-3">
+                                            <i data-feather="smile" class="h-6 w-6 text-green-600"></i>
+                                        </div>
+                                        <div class="ml-4">
+                                            <p class="text-sm font-medium text-gray-500">Wellbeing Pulse</p>
+                                            <p class="text-lg font-bold text-gray-900">74%</p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+<script>
+        document.addEventListener('DOMContentLoaded', function () {
+            if (window.feather) {
+                feather.replace();
+            }
+            if (window.AOS) {
+                AOS.init();
+            }
+
+            const sidebar = document.getElementById('sidebar');
+            const toggleButton = document.getElementById('sidebarToggle');
+
+            if (sidebar && toggleButton) {
+                toggleButton.addEventListener('click', function () {
+                    const isCollapsed = sidebar.classList.toggle('collapsed');
+                    toggleButton.setAttribute('aria-expanded', (!isCollapsed).toString());
+                    toggleButton.classList.toggle('rotate-180', isCollapsed);
+                });
+            }
+
+            const addTaskForm = document.getElementById('addTaskForm');
+            const newTaskInput = document.getElementById('newTaskText');
+            const newTaskTime = document.getElementById('newTaskTime');
+            const tasksList = document.getElementById('priorityTasksList');
+
+            if (addTaskForm && newTaskInput && tasksList) {
+                let taskCount = tasksList.querySelectorAll('li').length;
+
+                addTaskForm.addEventListener('submit', function (event) {
+                    event.preventDefault();
+
+                    const taskDescription = newTaskInput.value.trim();
+                    const taskTimeValue = newTaskTime ? newTaskTime.value : '';
+
+                    if (!taskDescription) {
+                        newTaskInput.focus();
+                        return;
+                    }
+
+                    taskCount += 1;
+                    const taskId = `task-${taskCount}`;
+
+                    const listItem = document.createElement('li');
+                    listItem.className = 'task-item py-4';
+
+                    const itemWrapper = document.createElement('div');
+                    itemWrapper.className = 'flex items-center';
+
+                    const checkbox = document.createElement('input');
+                    checkbox.type = 'checkbox';
+                    checkbox.id = taskId;
+                    checkbox.name = taskId;
+                    checkbox.className = 'task-checkbox h-4 w-4 text-green-600 focus:ring-green-500 border-gray-300 rounded';
+
+                    const label = document.createElement('label');
+                    label.setAttribute('for', taskId);
+                    label.className = 'ml-3 block';
+
+                    const descriptionSpan = document.createElement('span');
+                    descriptionSpan.className = 'task-text text-sm font-medium text-gray-700';
+                    descriptionSpan.textContent = taskDescription;
+
+                    const metaSpan = document.createElement('span');
+                    metaSpan.className = 'text-xs text-gray-500 block mt-1';
+                    metaSpan.textContent = taskTimeValue ? formatDueTime(taskTimeValue) : 'Added just now';
+
+                    label.appendChild(descriptionSpan);
+                    label.appendChild(metaSpan);
+
+                    itemWrapper.appendChild(checkbox);
+                    itemWrapper.appendChild(label);
+
+                    listItem.appendChild(itemWrapper);
+                    tasksList.appendChild(listItem);
+
+                    addTaskForm.reset();
+                    newTaskInput.focus();
+                });
+            }
+
+            function formatDueTime(timeString) {
+                const [hourString, minute] = timeString.split(':');
+                let hour = parseInt(hourString, 10);
+                if (Number.isNaN(hour)) {
+                    return 'Added just now';
+                }
+                const meridiem = hour >= 12 ? 'PM' : 'AM';
+                hour = hour % 12 || 12;
+                return `Due today at ${hour}:${minute} ${meridiem}`;
+            }
+        });
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- make the dashboard sidebar collapsible while keeping quick links to tasks, calendar, analytics, wellness, and settings
- add an input form so users can append new priority tasks with optional due times
- initialize icon/animation libraries and round out the team insights card metrics

## Testing
- not run (static HTML)


------
https://chatgpt.com/codex/tasks/task_b_68cdbf9177e48331a77cd17cbd2b2094