### PR TITLE
Fix corrupted UI markup and add wellness suggestion

### DIFF
--- a/analytics.html
+++ b/analytics.html
@@ -46,13 +46,13 @@
 </head>
 <body class="font-sans antialiased text-gray-800 bg-gray-50">
     <!-- Navigation -->
-    <nav class="bg极-white shadow-sm fixed w-full z-10">
+    <nav class="bg-white shadow-sm fixed w-full z-10">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex justify-between h-16">
                 <div class="flex items-center">
                     <div class="flex-shrink-0 flex items-center">
                         <i data-feather="activity" class="text-green-500 h-8 w-8"></i>
-                        <span class="ml-2 text-xl font-bold极 text-green-600">Ezro.AI</span>
+                        <span class="ml-2 text-xl font-bold text-green-600">Ezro.AI</span>
                     </div>
                 </div>
                 <div class="hidden sm:ml-6 sm:flex sm:space-x-8">
@@ -62,7 +62,7 @@
                     <a href="calendar.html" class="nav-link border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Calendar</a>
                     <a href="analytics.html" class="nav-link border-green-500 text-gray-900 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Analytics</a>
                 </div>
-                <div class="hidden sm:极ml-6 sm:flex sm:items-center">
+                <div class="hidden sm:ml-6 sm:flex sm:items-center">
                     <div class="ml-3 relative">
                         <div>
                             <button type="button" class="flex text-sm rounded-full focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500" id="user-menu-button" aria-expanded="false" aria-haspopup="true">
@@ -84,7 +84,7 @@
         <div class="sm:hidden hidden" id="mobile-menu">
             <div class="pt-2 pb-3 space-y-1">
                 <a href="index.html" class="border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700 block pl-3 pr-4 py-2 border-l-4 text-base font-medium">Home</a>
-                <a href="pricing.html" class="border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700 block pl-3 pr-4 py-2 border-l-极4 text-base font-medium">Pricing</a>
+                <a href="pricing.html" class="border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700 block pl-3 pr-4 py-2 border-l-4 text-base font-medium">Pricing</a>
                 <a href="dashboard.html" class="border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700 block pl-3 pr-4 py-2 border-l-4 text-base font-medium">Dashboard</a>
                 <a href="calendar.html" class="border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700 block pl-3 pr-4 py-2 border-l-4 text-base font-medium">Calendar</a>
                 <a href="analytics.html" class="bg-green-50 border-green-500 text-green-700 block pl-3 pr-4 py-2 border-l-4 text-base font-medium">Analytics</a>
@@ -97,7 +97,7 @@
                             <div class="text-base font-medium text-gray-800">John Doe</div>
                             <div class="text-sm font-medium text-gray-500">john@example.com</div>
                         </div>
-                    </极div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -107,8 +107,8 @@
     <div class="flex pt-16">
         <!-- Sidebar -->
         <div class="hidden md:flex md:flex-shrink-0">
-            <div class极="flex flex-col w-64 border-r border-gray-200 bg-white">
-                <div class="h-0 flex-1 flex极 flex-col pt-5 pb-4 overflow-y-auto">
+            <div class="sidebar flex flex-col w-64 border-r border-gray-200 bg-white">
+                <div class="h-0 flex-1 flex flex-col pt-5 pb-4 overflow-y-auto">
                     <div class="flex-1 px-3 space-y-1">
                         <a href="dashboard.html" class="sidebar-item group flex items-center px-2 py-2 text-sm font-medium rounded-md">
                             <i data-feather="home" class="mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500"></i>
@@ -127,11 +127,11 @@
                             Analytics
                         </a>
                         <a href="wellness.html" class="sidebar-item group flex items-center px-2 py-2 text-sm font-medium rounded-md">
-                            <i data-feather="heart" class="mr-3极 h-6 w-6 text-gray-400 group-hover:text-gray-500"></i>
+                            <i data-feather="heart" class="mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500"></i>
                             Wellness
                         </a>
                         <a href="settings.html" class="sidebar-item group flex items-center px-2 py-2 text-sm font-medium rounded-md">
-                            <极i data-feather="settings" class="mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500"></i>
+                            <i data-feather="settings" class="mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500"></i>
                             Settings
                         </a>
                     </div>
@@ -207,7 +207,7 @@
                         </div>
                     </div>
 
-                    <div class="stat-card bg-white overflow-hidden shadow rounded-lg p-6 transition duration-300 ease极-in-out">
+                    <div class="stat-card bg-white overflow-hidden shadow rounded-lg p-6 transition duration-300 ease-in-out">
                         <div class="flex items-center">
                             <div class="flex-shrink-0">
                                 <div class="w-12 h-12 rounded-full bg-purple-100 flex items-center justify-center">
@@ -327,7 +327,7 @@
                                 </div>
                                 <div class="bg-gray-50 p-4 rounded-lg">
                                     <div class="flex items-center">
-                                        <div class极="flex-shrink-0 bg-blue-100 rounded-md p-3">
+                                        <div class="flex-shrink-0 bg-blue-100 rounded-md p-3">
                                             <i data-feather="check-circle" class="h-6 w-6 text-blue-600"></i>
                                         </div>
                                         <div class="ml-4">
@@ -342,7 +342,7 @@
                                             <i data-feather="coffee" class="h-6 w-6 text-purple-600"></i>
                                         </div>
                                         <div class="ml-4">
-                                            <p class="text-sm font-medium text极-gray-500">Team Break Rate</p>
+                                            <p class="text-sm font-medium text-gray-500">Team Break Rate</p>
                                             <p class="text-lg font-bold text-gray-900">58%</p>
                                         </div>
                                     </div>

--- a/settings.html
+++ b/settings.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="极width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Settings - Ezro.AI</title>
     <link rel="icon" type="image/x-icon" href="/static/favicon.ico">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -26,7 +26,7 @@
             color: #38a169;
         }
         .sidebar-item:hover {
-            background-color: #极f0fff4;
+            background-color: #f0fff4;
         }
         .sidebar-item.active {
             background-color: #e6fffa;
@@ -52,7 +52,7 @@
                         <span class="ml-2 text-xl font-bold text-green-600">Ezro.AI</span>
                     </div>
                 </div>
-                <div class="hidden sm:ml-6 sm极:flex sm:space-x-8">
+                <div class="hidden sm:ml-6 sm:flex sm:space-x-8">
                     <a href="index.html" class="nav-link border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Home</a>
                     <a href="pricing.html" class="nav-link border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Pricing</a>
                     <a href="dashboard.html" class="nav-link border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Dashboard</a>
@@ -60,15 +60,15 @@
                     <a href="settings.html" class="nav-link border-green-500 text-gray-900 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Settings</a>
                 </div>
                 <div class="hidden sm:ml-6 sm:flex sm:items-center">
-                    <div class极="ml-3 relative">
+                    <div class="ml-3 relative">
                         <div>
-                            <button type="button" class="flex text-sm rounded-full focus:outline-none focus:ring极-2 focus:ring-offset-2 focus:ring-green-500" id="user-menu-button" aria-expanded="false" aria-haspopup="true">
+                            <button type="button" class="flex text-sm rounded-full focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500" id="user-menu-button" aria-expanded="false" aria-haspopup="true">
                                 <span class="sr-only">Open user menu</span>
                                 <img class="h-8 w-8 rounded-full" src="http://static.photos/people/200x200/4" alt="User profile">
                             </button>
                         </div>
                     </div>
-极                </div>
+                </div>
                 <div class="-mr-2 flex items-center sm:hidden">
                     <button type="button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-green-500" aria-controls="mobile-menu" aria-expanded="false">
                         <i data-feather="menu"></i>
@@ -80,10 +80,10 @@
         <!-- Mobile menu -->
         <div class="sm:hidden hidden" id="mobile-menu">
             <div class="pt-2 pb-3 space-y-1">
-                <a href="index.html" class="border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray极-700 block pl-3 pr-4 py-2 border-l-4 text-base font-medium">Home</a>
+                <a href="index.html" class="border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700 block pl-3 pr-4 py-2 border-l-4 text-base font-medium">Home</a>
                 <a href="pricing.html" class="border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700 block pl-3 pr-4 py-2 border-l-4 text-base font-medium">Pricing</a>
                 <a href="dashboard.html" class="border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700 block pl-3 pr-4 py-2 border-l-4 text-base font-medium">Dashboard</a>
-                <a href="calendar.html"极 class="border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700 block pl-3 pr-4 py-2 border-l-4 text-base font-medium">Calendar</a>
+                <a href="calendar.html" class="border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700 block pl-3 pr-4 py-2 border-l-4 text-base font-medium">Calendar</a>
                 <a href="settings.html" class="bg-green-50 border-green-500 text-green-700 block pl-3 pr-4 py-2 border-l-4 text-base font-medium">Settings</a>
                 <div class="pt-4 border-t border-gray-200">
                     <div class="flex items-center px-4">
@@ -105,24 +105,24 @@
         <!-- Sidebar -->
         <div class="hidden md:flex md:flex-shrink-0">
             <div class="flex flex-col w-64 border-r border-gray-200 bg-white">
-                <极div class="h-0 flex-1 flex flex-col pt-5 pb-4 overflow-y-auto">
-                    <div class="flex-极1 px-3 space-y-1">
+                <div class="h-0 flex-1 flex flex-col pt-5 pb-4 overflow-y-auto">
+                    <div class="flex-1 px-3 space-y-1">
                         <a href="dashboard.html" class="sidebar-item group flex items-center px-2 py-2 text-sm font-medium rounded-md">
                             <i data-feather="home" class="mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500"></i>
                             Dashboard
                         </a>
                         <a href="tasks.html" class="sidebar-item group flex items-center px-2 py-2 text-sm font-medium rounded-md">
-                            <i data-feather="check-circle" class="mr-3 h-6 w-6 text-gray-400 group-h极over:text-gray-500"></i>
+                            <i data-feather="check-circle" class="mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500"></i>
                             Tasks
                         </a>
                         <a href="calendar.html" class="sidebar-item group flex items-center px-2 py-2 text-sm font-medium rounded-md">
-                            <i data-feather="calendar" class="mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500"></极i>
+                            <i data-feather="calendar" class="mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500"></i>
                             Calendar
                         </a>
                         <a href="analytics.html" class="sidebar-item group flex items-center px-2 py-2 text-sm font-medium rounded-md">
                             <i data-feather="bar-chart-2" class="mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500"></i>
                             Analytics
-                        </极a>
+                        </a>
                         <a href="wellness.html" class="sidebar-item group flex items-center px-2 py-2 text-sm font-medium rounded-md">
                             <i data-feather="heart" class="mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500"></i>
                             Wellness
@@ -139,7 +139,7 @@
                             <img class="h-10 w-10 rounded-full" src="http://static.photos/people/200x200/4" alt="User profile">
                         </div>
                         <div class="ml-3">
-                            <p class="text-base font-medium text-gray-700">John Doe</极p>
+                            <p class="text-base font-medium text-gray-700">John Doe</p>
                             <p class="text-sm font-medium text-gray-500">View profile</p>
                         </div>
                     </div>
@@ -233,7 +233,7 @@
                                 </div>
                                 <label class="relative inline-flex items-center cursor-pointer">
                                     <input type="checkbox" class="sr-only peer" checked>
-                                    <div class="w-11极 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-green-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after极:content-[''] after:absolute after:top-[2px] after:left-[2极px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-green-600"></div>
+                                    <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-green-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-green-600"></div>
                                 </label>
                             </div>
                             <div class="flex items-center justify-between">
@@ -243,7 +243,7 @@
                                 </div>
                                 <label class="relative inline-flex items-center cursor-pointer">
                                     <input type="checkbox" class="sr-only peer" checked>
-                                    <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:极ring-green-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-green-600"></div>
+                                    <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-green-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-green-600"></div>
                                 </label>
                             </div>
                             <div class="flex items-center justify-between">
@@ -253,7 +253,7 @@
                                 </div>
                                 <label class="relative inline-flex items-center cursor-pointer">
                                     <input type="checkbox" class="sr-only peer">
-                                    <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-green-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:极bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-green-600"></div>
+                                    <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-green-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-green-600"></div>
                                 </label>
                             </div>
                         </div>
@@ -295,7 +295,7 @@
                                 </div>
                                 <label class="relative inline-flex items-center cursor-pointer">
                                     <input type="checkbox" class="sr-only peer">
-                                    <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-green-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked极:bg-green-600"></div>
+                                    <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-green-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-green-600"></div>
                                 </label>
                             </div>
                         </div>
@@ -325,7 +325,7 @@
                                 </button>
                             </div>
                             <div class="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
-                                <div class极="flex items-center">
+                                <div class="flex items-center">
                                     <div class="flex-shrink-0 bg-purple-100 rounded-md p-2">
                                         <i data-feather="trello" class="h-5 w-5 text-purple-600"></i>
                                     </div>
@@ -335,7 +335,7 @@
                                     </div>
                                 </div>
                                 <button class="text-green-600 hover:text-green-800 text-sm font-medium">
-                                    <i data-feather="link" class="h-4 w-4"></极i>
+                                    <i data-feather="link" class="h-4 w-4"></i>
                                 </button>
                             </div>
                             <div class="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
@@ -394,7 +394,7 @@
                     <!-- Account Settings -->
                     <div class="setting-card bg-white overflow-hidden shadow rounded-lg">
                         <div class="px-4 py-5 sm:px-6 border-b border-gray-200">
-                            <h3 class="text-lg leading-6 font-medium text极-gray-900">
+                            <h3 class="text-lg leading-6 font-medium text-gray-900">
                                 <i data-feather="user" class="h-5 w-5 text-green-600 mr-2 inline"></i>
                                 Account
                             </h3>

--- a/tasks.html
+++ b/tasks.html
@@ -51,7 +51,7 @@
 <body class="font-sans antialiased text-gray-800 bg-gray-50">
     <!-- Navigation -->
     <nav class="bg-white shadow-sm fixed w-full z-10">
-        <div class="max-w-7xl mx-auto px-4 sm极:px-6 lg:px-8">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex justify-between h-16">
                 <div class="flex items-center">
                     <div class="flex-shrink-0 flex items-center">
@@ -61,7 +61,7 @@
                 </div>
                 <div class="hidden sm:ml-6 sm:flex sm:space-x-8">
                     <a href="index.html" class="nav-link border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Home</a>
-                    <a href="pricing.html" class="nav-link border-transparent text极-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Pricing</a>
+                    <a href="pricing.html" class="nav-link border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Pricing</a>
                     <a href="dashboard.html" class="nav-link border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Dashboard</a>
                     <a href="calendar.html" class="nav-link border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Calendar</a>
                     <a href="tasks.html" class="nav-link border-green-500 text-gray-900 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Tasks</a>
@@ -77,7 +77,7 @@
                     </div>
                 </div>
                 <div class="-mr-2 flex items-center sm:hidden">
-                    <button type="button" class="inline-flex items-center justify-center p-2极 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:out极line-none focus:ring-2 focus:ring-inset focus:ring-green-500" aria-controls="mobile-menu" aria-expanded="false">
+                    <button type="button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-green-500" aria-controls="mobile-menu" aria-expanded="false">
                         <i data-feather="menu"></i>
                     </button>
                 </div>
@@ -88,13 +88,13 @@
         <div class="sm:hidden hidden" id="mobile-menu">
             <div class="pt-2 pb-3 space-y-1">
                 <a href="index.html" class="border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700 block pl-3 pr-4 py-2 border-l-4 text-base font-medium">Home</a>
-                <a href="pricing.html" class="border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700 block pl-3 pr-4 py-2 border-l-4 text-base font-medium">Pricing</极a>
+                <a href="pricing.html" class="border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700 block pl-3 pr-4 py-2 border-l-4 text-base font-medium">Pricing</a>
                 <a href="dashboard.html" class="border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700 block pl-3 pr-4 py-2 border-l-4 text-base font-medium">Dashboard</a>
                 <a href="calendar.html" class="border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700 block pl-3 pr-4 py-2 border-l-4 text-base font-medium">Calendar</a>
                 <a href="tasks.html" class="bg-green-50 border-green-500 text-green-700 block pl-3 pr-4 py-2 border-l-4 text-base font-medium">Tasks</a>
                 <div class="pt-4 border-t border-gray-200">
                     <div class="flex items-center px-4">
-                        <div class极="flex-shrink-0">
+                        <div class="flex-shrink-0">
                             <img class="h-10 w-10 rounded-full" src="http://static.photos/people/200x200/4" alt="User profile">
                         </div>
                         <div class="ml-3">
@@ -119,10 +119,10 @@
                             Dashboard
                         </a>
                         <a href="tasks.html" class="sidebar-item active group flex items-center px-2 py-2 text-sm font-medium rounded-md">
-                            <i data-feather="check-circle" class="mr-3 h-6 w-6 text-green-500"></极i>
+                            <i data-feather="check-circle" class="mr-3 h-6 w-6 text-green-500"></i>
                             Tasks
                         </a>
-                        <a href="calendar.html" class="sidebar-item group flex items-center px-2 py-2 text极-sm font-medium rounded-md">
+                        <a href="calendar.html" class="sidebar-item group flex items-center px-2 py-2 text-sm font-medium rounded-md">
                             <i data-feather="calendar" class="mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500"></i>
                             Calendar
                         </a>
@@ -143,10 +143,10 @@
                 <div class="flex-shrink-0 flex border-t border-gray-200 p-4">
                     <div class="flex items-center">
                         <div>
-                            <img class="极h-10 w-10 rounded-full" src="http://static.photos/people/200x200/4极" alt="User profile">
+                            <img class="h-10 w-10 rounded-full" src="http://static.photos/people/200x200/4" alt="User profile">
                         </div>
                         <div class="ml-3">
-                            <p class="text-base font-medium text-gray-极700">John Doe</p>
+                            <p class="text-base font-medium text-gray-700">John Doe</p>
                             <p class="text-sm font-medium text-gray-500">View profile</p>
                         </div>
                     </div>
@@ -210,7 +210,7 @@
                                         <input id="task-2" name="task-2" type="checkbox" class="task-checkbox h-4 w-4 text-green-600 focus:ring-green-500 border-gray-300 rounded">
                                         <label for="task-2" class="ml-3 block">
                                             <span class="task-text text-sm font-medium text-gray-700">Review team's quarterly performance metrics</span>
-                                            <span class="text-xs text-gray-500 block mt极-1">Due today at 4:30 PM</span>
+                                            <span class="text-xs text-gray-500 block mt-1">Due today at 4:30 PM</span>
                                         </label>
                                     </div>
                                 </li>
@@ -229,13 +229,13 @@
 
                     <!-- Upcoming Tasks -->
                     <div class="bg-white overflow-hidden shadow rounded-lg">
-                        <div class="px-4 py-5 sm:px极-6 border-b border-gray-200">
+                        <div class="px-4 py-5 sm:px-6 border-b border-gray-200">
                             <h3 class="text-lg leading-6 font-medium text-gray-900">
                                 Upcoming Tasks
                             </h3>
                             <p class="mt-1 text-sm text-gray-500">
                                 Due this week
-                            </极p>
+                            </p>
                         </div>
                         <div class="px-4 py-5 sm:p-6">
                             <ul class="divide-y divide-gray-200" id="upcoming-tasks">
@@ -255,7 +255,7 @@
                                             <span class="task-text text-sm font-medium text-gray-700">Follow up with marketing on campaign results</span>
                                             <span class="text-xs text-gray-500 block mt-1">Due tomorrow at 11:00 AM</span>
                                         </label>
-                                    </极div>
+                                    </div>
                                 </li>
                                 <li class="task-item py-4 priority-low">
                                     <div class="flex items-center">
@@ -302,7 +302,7 @@
                                 </li>
                                 <li class="task-item py-4">
                                     <div class="flex items-center">
-                                        <input id="task-9" name="task-9极" type="checkbox" class="task-checkbox h-4 w-4 text-green-600 focus:ring-green-500 border-gray-300 rounded" checked>
+                                        <input id="task-9" name="task-9" type="checkbox" class="task-checkbox h-4 w-4 text-green-600 focus:ring-green-500 border-gray-300 rounded" checked>
                                         <label for="task-9" class="ml-3 block">
                                             <span class="task-text text-sm font-medium text-gray-500">Review project timeline</span>
                                             <span class="text-xs text-gray-400 block mt-1">Completed yesterday at 4:00 PM</span>
@@ -344,8 +344,8 @@
                         <p class="mt-2 text-3xl font-bold text-gray-900" data-stat="total">9</p>
                     </div>
                     <div class="bg-white overflow-hidden shadow rounded-lg p-6 text-center">
-                        <div class="flex items-center justify-center h-12极 w-12 rounded-md bg-green-100 text-green-600 mx-auto">
-                            <i data-feather="check-square"></极i>
+                        <div class="flex items-center justify-center h-12 w-12 rounded-md bg-green-100 text-green-600 mx-auto">
+                            <i data-feather="check-square"></i>
                         </div>
                         <h3 class="mt-4 text-lg font-medium text-gray-900">Completed</h3>
                         <p class="mt-2 text-3xl font-bold text-gray-900" data-stat="completed">3</p>

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import sync_playwright
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="session")
+def playwright_context():
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch()
+        context = browser.new_context()
+        yield context
+        context.close()
+        browser.close()
+
+
+@pytest.fixture()
+def page(playwright_context):
+    page = playwright_context.new_page()
+    yield page
+    page.close()
+
+
+def test_settings_page_inputs_are_editable(page):
+    page.goto((ROOT / "settings.html").as_uri())
+    name_input = page.locator("label:has-text('Full Name') + input")
+    name_input.fill("Jamie Doe")
+    assert name_input.input_value() == "Jamie Doe"
+
+
+def test_tasks_page_add_task_button_opens_modal(page):
+    page.goto((ROOT / "tasks.html").as_uri())
+    page.get_by_role("button", name="Add Task").click()
+    modal_class_list = page.eval_on_selector("#task-modal", "el => el.className")
+    assert "hidden" not in modal_class_list.split()

--- a/wellness.html
+++ b/wellness.html
@@ -8,7 +8,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
-    <script src="https://cdn.jsdeliv极r.net/npm/feather-icons/dist/feather.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/feather-icons/dist/feather.min.js"></script>
     <script src="https://unpkg.com/feather-icons"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
@@ -21,7 +21,7 @@
         }
         .btn-primary:hover {
             transform: translateY(-2px);
-            box-shadow: 0 10极px 20px rgba(72, 187, 120, 0.2);
+            box-shadow: 0 10px 20px rgba(72, 187, 120, 0.2);
         }
         .nav-link:hover {
             color: #38a169;
@@ -54,22 +54,22 @@
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex justify-between h-16">
                 <div class="flex items-center">
-                    <div class="flex-shrink-0 flex items极-center">
-                        <i data-feather="activity" class="text-green-500 h-8极 w-8"></i>
+                    <div class="flex-shrink-0 flex items-center">
+                        <i data-feather="activity" class="text-green-500 h-8 w-8"></i>
                         <span class="ml-2 text-xl font-bold text-green-600">Ezro.AI</span>
                     </div>
                 </div>
                 <div class="hidden sm:ml-6 sm:flex sm:space-x-8">
                     <a href="index.html" class="nav-link border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Home</a>
                     <a href="pricing.html" class="nav-link border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Pricing</a>
-                    <a href="dashboard.html" class="nav-link border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Dashboard</极a>
+                    <a href="dashboard.html" class="nav-link border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Dashboard</a>
                     <a href="calendar.html" class="nav-link border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Calendar</a>
                     <a href="wellness.html" class="nav-link border-green-500 text-gray-900 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">Wellness</a>
                 </div>
                 <div class="hidden sm:ml-6 sm:flex sm:items-center">
                     <div class="ml-3 relative">
                         <div>
-                            <button type="button" class极="flex text-sm rounded-full focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500" id="user-menu-button" aria-expanded="false" aria-haspopup="true">
+                            <button type="button" class="flex text-sm rounded-full focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500" id="user-menu-button" aria-expanded="false" aria-haspopup="true">
                                 <span class="sr-only">Open user menu</span>
                                 <img class="h-8 w-8 rounded-full" src="http://static.photos/people/200x200/4" alt="User profile">
                             </button>
@@ -77,7 +77,7 @@
                     </div>
                 </div>
                 <div class="-mr-2 flex items-center sm:hidden">
-                    <button type="button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-green-500" aria-controls="mobile-menu" aria-expanded极="false">
+                    <button type="button" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-green-500" aria-controls="mobile-menu" aria-expanded="false">
                         <i data-feather="menu"></i>
                     </button>
                 </div>
@@ -90,20 +90,20 @@
                 <a href="index.html" class="border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700 block pl-3 pr-4 py-2 border-l-4 text-base font-medium">Home</a>
                 <a href="pricing.html" class="border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700 block pl-3 pr-4 py-2 border-l-4 text-base font-medium">Pricing</a>
                 <a href="dashboard.html" class="border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700 block pl-3 pr-4 py-2 border-l-4 text-base font-medium">Dashboard</a>
-                <a href="calendar.html" class="border-transparent text-gray-500 hover:bg-gray极-50 hover:border-gray-300 hover:text-gray-700 block pl-3 pr-4 py-2 border-l-4极 text-base font-medium">Calendar</a>
-                <a href="wellness.html" class="bg-green-50 border-green-500 text-green-700 block pl-3 pr-4 py-极2 border-l-4 text-base font-medium">Wellness</a>
+                <a href="calendar.html" class="border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700 block pl-3 pr-4 py-2 border-l-4 text-base font-medium">Calendar</a>
+                <a href="wellness.html" class="bg-green-50 border-green-500 text-green-700 block pl-3 pr-4 py-2 border-l-4 text-base font-medium">Wellness</a>
                 <div class="pt-4 border-t border-gray-200">
-                    <div class="flex items-center px极-4">
+                    <div class="flex items-center px-4">
                         <div class="flex-shrink-0">
                             <img class="h-10 w-10 rounded-full" src="http://static.photos/people/200x200/4" alt="User profile">
                         </div>
                         <div class="ml-3">
                             <div class="text-base font-medium text-gray-800">John Doe</div>
-                            <div class="text-sm font-medium text-gray-500极">john@example.com</div>
+                            <div class="text-sm font-medium text-gray-500">john@example.com</div>
                         </div>
                     </div>
                 </div>
-极            </div>
+            </div>
         </div>
     </nav>
 
@@ -123,7 +123,7 @@
                             Tasks
                         </a>
                         <a href="calendar.html" class="sidebar-item group flex items-center px-2 py-2 text-sm font-medium rounded-md">
-                            <i data-feather极="calendar" class="mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500"></i>
+                            <i data-feather="calendar" class="mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500"></i>
                             Calendar
                         </a>
                         <a href="analytics.html" class="sidebar-item group flex items-center px-2 py-2 text-sm font-medium rounded-md">
@@ -140,7 +140,7 @@
                         </a>
                     </div>
                 </div>
-                <div class="极flex-shrink-0 flex border-t border-gray-200 p-极4">
+                <div class="flex-shrink-0 flex border-t border-gray-200 p-4">
                     <div class="flex items-center">
                         <div>
                             <img class="h-10 w-10 rounded-full" src="http://static.photos/people/200x200/4" alt="User profile">
@@ -282,8 +282,19 @@
                                             <i data-feather="droplet" class="h-4 w-4 text-purple-600"></i>
                                         </div>
                                         <div class="ml-3">
-                                            <p class极="text-sm font-medium text-gray-900">Hydration Break</p>
+                                            <p class="text-sm font-medium text-gray-900">Hydration Break</p>
                                             <p class="text-xs text-gray-500">Drink a glass of water</p>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="nudge-card p-3 bg-gray-50 rounded-lg transition duration-300 ease-in-out">
+                                    <div class="flex items-center">
+                                        <div class="flex-shrink-0 bg-pink-100 rounded-md p-2">
+                                            <span role="img" aria-label="open book" class="text-lg">📖</span>
+                                        </div>
+                                        <div class="ml-3">
+                                            <p class="text-sm font-medium text-gray-900">Read a short creative story</p>
+                                            <p class="text-xs text-gray-500">Spend a few minutes with a calming micro-tale</p>
                                         </div>
                                     </div>
                                 </div>
@@ -330,7 +341,7 @@
                                 Break types and frequency
                             </p>
                         </div>
-                        <极div class="px-4 py-5 sm:p-6">
+                        <div class="px-4 py-5 sm:p-6">
                             <canvas id="breakDistributionChart" height="250"></canvas>
                         </div>
                     </div>
@@ -338,7 +349,7 @@
 
                 <!-- Wellness Goals -->
                 <div class="bg-white overflow-hidden shadow rounded-lg mb-8">
-                    <div class="px-4 py-5 sm:px-6 border极-b border-gray-200">
+                    <div class="px-4 py-5 sm:px-6 border-b border-gray-200">
                         <h3 class="text-lg leading-6 font-medium text-gray-900">
                             Wellness Goals
                         </h3>


### PR DESCRIPTION
## Summary
- restore Tailwind classes and viewport metadata across the settings and tasks pages so navigation and layout elements render correctly
- clean up the analytics sidebar markup so it matches the dashboard width and styling
- add a new pastel book themed break suggestion to the wellness page and cover key interactions with Playwright UI tests

## Testing
- pytest tests/test_ui.py

------
https://chatgpt.com/codex/tasks/task_b_68cdc5aacc5c83319c5487a6593b4897